### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Margays/eir/security/code-scanning/1](https://github.com/Margays/eir/security/code-scanning/1)

To resolve this issue, we need to add an explicit `permissions` block to the workflow to limit the `GITHUB_TOKEN` privileges to the minimum required for the CI workflow. Since the CI workflow only pulls code and performs checks like building, formatting, linting, and testing, it does not require any `write` permissions. The `contents: read` permission is sufficient.

The `permissions` block should be added at the workflow root level, ensuring it applies to all jobs in the workflow. This change will prevent the workflow from inheriting potentially excessive repository permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
